### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A little script to prune old Docker images from the Google Container Registry.
 
 The script requires Python 2.7. You can run it with `./prune-gcr --project <project> <repository>`. If `--project` is not specified, it will attempt to infer the default project from your gcloud configuration.
 
-```sh
+```
 usage: prune-gcr [-h] [--project PROJECT] [--older-than CUTOFF]
                  [--keep-at-least N]
                  repository


### PR DESCRIPTION
`'` seems to mess `sh` formatting.

now:
![Screenshot 2020-04-27 at 10 24 04](https://user-images.githubusercontent.com/5256730/80350683-624b3780-8871-11ea-9303-87d9de6afc88.png)

vs

previously:
![Screenshot 2020-04-27 at 10 23 51](https://user-images.githubusercontent.com/5256730/80350688-6414fb00-8871-11ea-80b1-4ceeacfd9dc4.png)
