### PR TITLE
Fix parsing datetime + Add --dry-run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,10 @@ jobs:
       with:
         python-version: '2.7'
     - name: Use a stub for gcloud in subsequent steps
-      run: echo '::add-path::${{ github.workspace }}/testing/bin'
+      run: echo "${{ github.workspace }}/testing/bin" >> $GITHUB_PATH
     - name: Test the help text
       run: echo $PATH && ./prune-gcr --help
     - name: Run the script end-to-end with a mock repository
-      run: ./prune-gcr test-project
+      run: ./prune-gcr --project test-project mock-repository
     - name: Test a mock empty repository
-      run: ./prune-gcr empty
-      
+      run: ./prune-gcr --project test-project empty

--- a/prune-gcr
+++ b/prune-gcr
@@ -44,6 +44,11 @@ def main():
         metavar="N",
         help="keep at least N images, even if they are older than the cutoff date. Defaults to 50.",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="actually don't remove the old images, just print them",
+    )
     args = parser.parse_args()
 
     repository = "gcr.io/{project}/{name}".format(
@@ -54,7 +59,13 @@ def main():
         repository, args.older_than, keep_at_least=args.keep_at_least
     )
 
-    delete_images(repository, digests)
+    if args.dry_run:
+        if len(digests) > 0:
+            print "This is a dry run mode. Run without --dry-run to remove the following images:"
+        for digest in digests:
+            print "- {}".format(digest)
+    else:
+        delete_images(repository, digests)
 
 
 def get_default_project():

--- a/prune-gcr
+++ b/prune-gcr
@@ -116,7 +116,7 @@ def last_index_older_than(entries, older_than):
     # backwards to find the first one older than the specified date
     for index, entry in reversed(list(enumerate(entries))):
         # Reformat the timestamp so Python can parse it
-        timestamp = re.sub(r"-(\d\d):(\d\d)$", r"", entry["timestamp"]["datetime"])
+        timestamp = re.sub(r"[-+](\d\d):(\d\d)$", r"", entry["timestamp"]["datetime"])
         entry_time = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S").date()
         if entry_time < older_than:
             return index + 1

--- a/prune-gcr
+++ b/prune-gcr
@@ -47,7 +47,7 @@ def main():
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="actually don't remove the old images, just print them",
+        help="don't actually remove the old images, just print them",
     )
     args = parser.parse_args()
 

--- a/testing/mock-gcr-image-tags.json
+++ b/testing/mock-gcr-image-tags.json
@@ -2,7 +2,7 @@
   {
     "digest": "sha256:545a9ede29a8c41b9d21a718d726852bc3e034e24d50b1340b7d26b748ebc2a2",
     "timestamp": {
-      "datetime": "2019-11-28 07:19:48-08:00",
+      "datetime": "2019-11-28 07:19:48+02:00",
       "day": 28,
       "hour": 7,
       "microsecond": 0,


### PR DESCRIPTION
# Why

This script doesn't parse datetime strings from `+\d` timezones, e.g. `+00:00`. 

See the `prune-gcr` step in `www_production`: https://app.circleci.com/pipelines/github/expo/universe/20088/workflows/3820de63-a498-41df-b235-5b93ba13fe62/jobs/391290
This actually fails because `gcloud container images list-tags ...` returns timestamps like `....+00:00`.

It looks like it's been broken for a good while. There are >1300 www images in our GCloud registry.

# How

- I fixed parsing timestamps - updated the regex `-` -> `[-+]`.
- I also added a useful feature - `--dry-run` flag.
- I fixed failing tests and updated `mock-gcr-image-tags.json` so it includes a timestamp from the `+02:00` timezone.

# Test Plan

I made this change:
<img width="795" alt="Screenshot 2020-12-21 at 18 39 16" src="https://user-images.githubusercontent.com/5256730/102805665-da93d980-43bb-11eb-95a9-efd7aac0a405.png">

and then ran the script:

<img width="1256" alt="Screenshot 2020-12-21 at 18 35 07" src="https://user-images.githubusercontent.com/5256730/102805678-df588d80-43bb-11eb-9a11-65cf14fca279.png">
