### PR TITLE
[ci] Upgrade Black

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Tests
-on: push
+on:
+  push:
+    branches: master
+  pull_request:
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -11,9 +14,9 @@ jobs:
     - name: Install pip
       run: python -m pip install --upgrade pip
     - name: Install Black
-      run: pip install 'black==21.10b0'
+      run: pip install 'black==22.1'
     - name: Check formatting
-      run: black --check --target-version py27 prune-gcr
+      run: black --check prune-gcr
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Black 22.1.0 is now out of beta. Upgrade it in CI (no changes to formatting needed though). Remove target-version option since prune-gcr now uses Python 3 instead of 2.7.